### PR TITLE
Propose adding the "Are" keyword to the list of boolean string

### DIFF
--- a/SpecLight/Infrastructure/StringHelpers.cs
+++ b/SpecLight/Infrastructure/StringHelpers.cs
@@ -25,6 +25,8 @@ shall False=shan't
 shall True=shall
 is False=isn't
 is True=is
+are False=aren't
+are True=are
 ".Trim().Split('\n').Select(x => x.Trim().Split('=')).ToDictionary(x => x[0], x => x[1]);
 
         internal static string CreateText(MethodInfo method, object[] args)


### PR DESCRIPTION
replacements.

Currently there doesn't seem to be a verb that's great for describing a property that belongs to a set of objects.
Adding the "Are" keyword to the list of replacements seems like it would cater for this.

Use case: The fund totals are stale
The fund totals aren't stale